### PR TITLE
Take advanted of imminent EOL of Ubuntu 20 to update GH runner config…

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,13 +3,13 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          sudo apt install build-essential meson appstream clang clang-format clang-tools libdbus-1-dev libinih-dev libsystemd-dev
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential meson appstream clang clang-format clang-tools libdbus-1-dev libinih-dev libsystemd-dev systemd-dev
       - name: Check format
         env:
           CI: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /builddir
 /subprojects/packagecache/
+/subprojects/inih-r*

--- a/README.md
+++ b/README.md
@@ -66,15 +66,16 @@ The design of GameMode has a clear-cut abstraction between the host daemon and l
 See repository subdirectories for information on each component.
 
 ### Install Dependencies
-GameMode depends on `meson` for building and `systemd` for internal communication. This repo contains a `bootstrap.sh` script to allow for quick install to the user bus, but check `meson_options.txt` for custom settings.
+GameMode depends on `meson` for building and `systemd` for internal communication. This repo contains a `bootstrap.sh` script to allow for quick install to the user bus, but check `meson_options.txt` for custom settings. These instructions all assume that you
+already have a C development environment (gcc or clang, libc-devel, etc) installed.
 
-#### Ubuntu/Debian (you may also need `dbus-user-session`)
-
+#### Ubuntu/Debian
+Note: Debian 13 and Ubuntu 25.04 (and later) need to install `systemd-dev` in addition to the dependencies below.
 ```bash
-apt install meson libsystemd-dev pkg-config ninja-build git libdbus-1-dev libinih-dev build-essential
+apt update && apt install meson libsystemd-dev pkg-config ninja-build git dbus-user-session libdbus-1-dev libinih-dev build-essential
 ```
 
-On Ubuntu 18.04, you'll need to install `python3` package and install the latest meson version from `pip`.
+On Debian 12 and Ubuntu 22 (and earlier), you'll need to install `python3` and `python3-venv` packages to install the latest meson version from `pip`.
 
 ```bash
 python3 -m venv .venv
@@ -91,12 +92,28 @@ rm -rf .venv
 
 #### Arch
 ```bash
-pacman -S meson systemd git dbus libinih
+pacman -S meson systemd git dbus libinih gcc pkgconf
 ```
+
+#### RHEL 10 and variants
+Note: Older versions of RHEL (and variants) cannot build gamemode due to not exposing libdbus-1 to pkg-config.
+(also - don't try and play games on RHEL, come on)
+
+You must have [EPEL](https://docs.fedoraproject.org/en-US/epel/getting-started/) enabled to install all dependencies.
+```bash
+dnf install meson systemd-devel pkg-config git dbus-devel inih-devel
+```
+
 #### Fedora
 ```bash
-dnf install meson systemd-devel pkg-config git dbus-devel
+dnf install meson systemd-devel pkg-config git dbus-devel inih-devel
 ```
+
+#### OpenSUSE Leap/Tumbleweed
+```bash
+zypper install meson systemd-devel git dbus-1-devel libgcc_s1 libstdc++-devel libinih-devel
+```
+
 #### Gentoo
 Gentoo has an ebuild which builds a stable release from sources. It will also pull in all the dependencies so you can work on the source code.
 ```bash
@@ -105,6 +122,12 @@ emerge --ask games-util/gamemode
 You can also install using the latest sources from git:
 ```bash
 ACCEPT_KEYWORDS="**" emerge --ask ~games-util/gamemode-9999
+```
+
+#### Nix
+Similar to Gentoo, nixOS already has a package for gamemode, so we can use that to setup an environment:
+```bash
+nix-shell -p pkgs.gamemode.buildInputs pkgs.gamemode.nativeBuildInputs
 ```
 
 ### Build and Install GameMode

--- a/data/meson.build
+++ b/data/meson.build
@@ -9,7 +9,7 @@ data_conf.set('GAMEMODE_PRIVILEGED_GROUP', with_privileged_group)
 # Pull in the example config
 config_example = run_command(
     'cat',
-    join_paths(meson.source_root(), 'example', 'gamemode.ini'),
+    join_paths(meson.project_source_root(), 'example', 'gamemode.ini'),
     check: true,
 ).stdout().strip()
 data_conf.set('GAMEMODE_EXAMPLE_CONFIG', config_example)

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ project(
     default_options : ['c_std=c11', 'warning_level=3'],
     version: '1.8.2',
     license: 'BSD',
+    meson_version: '>= 1.3.1',
 )
 
 am_cflags = [
@@ -112,7 +113,7 @@ if sd_bus_provider == 'systemd'
         if path_systemd_unit_dir == ''
             message('Asking pkg-config for systemd\'s \'systemduserunitdir\' directory')
             pkgconfig_systemd = dependency('systemd')
-            path_systemd_unit_dir = pkgconfig_systemd.get_pkgconfig_variable('systemduserunitdir')
+            path_systemd_unit_dir = pkgconfig_systemd.get_variable(pkgconfig: 'systemduserunitdir')
         endif
     endif
     if with_privileged_group != ''
@@ -122,7 +123,7 @@ if sd_bus_provider == 'systemd'
           if path_systemd_group_dir == ''
               message('Asking pkg-config for systemd\'s \'sysusersdir\' directory')
               pkgconfig_systemd = dependency('systemd')
-              path_systemd_group_dir = pkgconfig_systemd.get_pkgconfig_variable('sysusersdir')
+              path_systemd_group_dir = pkgconfig_systemd.get_variable(pkgconfig: 'sysusersdir')
           endif
       endif
     else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,20 +1,20 @@
 # limits.d
-option('with-pam-renicing', type: 'boolean', description: 'Install the limits.d configuration file to allow renicing as a user being part of the privileged gamemode group', value: 'true')
+option('with-pam-renicing', type: 'boolean', description: 'Install the limits.d configuration file to allow renicing as a user being part of the privileged gamemode group', value: true)
 option('with-pam-limits-dir', type: 'string', description: 'Explicitly set the PAM limits.d directory', value: '/etc/security/limits.d')
 
 # sd-bus provider
 option('with-sd-bus-provider', type: 'combo', choices: ['systemd', 'elogind', 'no-daemon'], value: 'systemd')
 
 # systemd specific
-option('with-systemd-user-unit', type: 'boolean', description: 'Install systemd user unit', value: 'true')
+option('with-systemd-user-unit', type: 'boolean', description: 'Install systemd user unit', value: true)
 option('with-systemd-user-unit-dir', type: 'string', description: 'Explicitly set the systemd user unit directory')
-option('with-systemd-group', type: 'boolean', description: 'Install privileged gamemode group with systemd', value: 'true')
+option('with-systemd-group', type: 'boolean', description: 'Install privileged gamemode group with systemd', value: true)
 option('with-systemd-group-dir', type: 'string', description: 'Explicitly set the systemd group directory')
 
 # Not using systemd
 option('with-dbus-service-dir', type: 'string', description: 'Explicitly set the D-BUS session directory')
 
 # General options
-option('with-examples', type: 'boolean', description: 'Build sample programs', value: 'true')
-option('with-util', type: 'boolean', description: 'Build the utilities', value: 'true')
+option('with-examples', type: 'boolean', description: 'Build sample programs', value: true)
+option('with-util', type: 'boolean', description: 'Build the utilities', value: true)
 option('with-privileged-group', type: 'string', description: 'Group that has access to privileged gamemode features', value: 'gamemode')

--- a/subprojects/inih.wrap
+++ b/subprojects/inih.wrap
@@ -1,10 +1,9 @@
 [wrap-file]
-directory = inih-r54
-source_url = https://github.com/benhoyt/inih/archive/r54.tar.gz
-source_filename = inih-r54.tar.gz
-source_hash = b5566af5203f8a49fda27f1b864c0c157987678ffbd183280e16124012869869
+directory = inih-r60
+source_url = https://github.com/benhoyt/inih/archive/r60.tar.gz
+source_filename = inih-r60.tar.gz
+source_hash = 706aa05c888b53bd170e5d8aa8f8a9d9ccf5449dfed262d5103d1f292af26774
 
 [provide]
 inih = inih_dep
 inireader = INIReader_dep
-


### PR DESCRIPTION
…. Also make a pass over the development section of the README to reflect current reality. Update inih to r60. Update meson settings to eliminate deprecated functions. Set minimum Meson version to 1.3.1 to match Ubuntu 24 and OpenSUSE Leap 15.6.