### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,8 @@
 name: Build and test
 on: [push, pull_request]
+permissions:
+  contents: read
+  actions: write
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Potential fix for [https://github.com/a5ehren/gamemode/security/code-scanning/2](https://github.com/a5ehren/gamemode/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily reads repository contents and uploads logs as artifacts. Therefore, the `contents: read` and `actions: write` permissions are sufficient. The `actions: write` permission is needed for the `actions/upload-artifact` step.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
